### PR TITLE
Because for some reason I really like refactoring Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,30 @@
 FROM alpine:3.6
 
-CMD ["/usr/local/bin/redis-server", "--dir", "/var/lib/redis"]
+ENV RELEASE=4.0-rc3
 
-RUN apk --no-cache --update add \
-        autoconf \
-        g++ \
-        gcc \
-        git \
-        jemalloc-dev \
-        linux-headers \
-        make \
-    && \
-    git clone --branch 4.0-rc3 https://github.com/antirez/redis.git /tmp/redis && \
+WORKDIR /var/lib/redis
+
+RUN apk --no-cache add \
+        --virtual build-dependencies \
+          autoconf \
+          g++ \
+          gcc \
+          git \
+          jemalloc-dev \
+          linux-headers \
+          make && \
+    git clone --depth=1 --branch ${RELEASE} https://github.com/antirez/redis.git /tmp/redis/&& \
     cd /tmp/redis && \
-    make && \
+    make -j && \
     make install && \
     cp /tmp/redis/src/redis-trib.rb /usr/local/bin && \
-    rm -rf /tmp/* && \
-    apk del \
-        autoconf \
-        g++ \
-        gcc \
-        git \
-        jemalloc-dev \
-        linux-headers \
-        make \
-    && \
-    mkdir /var/lib/redis && \
-    chown guest /var/lib/redis
+    rm -rf /tmp/redis && \
+    chown guest /var/lib/redis && \
+    apk del build-dependencies
 
 USER guest
+
+EXPOSE 6379
+
+ENTRYPOINT ["/usr/local/bin/redis-server"]
+CMD ["--dir", "/var/lib/redis"]


### PR DESCRIPTION
Tested out locally and builds and runs the same as original `Dockerfile`, image size is slightly smaller,

```
🐳  docker images | grep -i redis4-docker
redis4-docker                refactor            f8b1d1e84b43        3 minutes ago       21.5MB
redis4-docker                orig                0287ca469084        31 minutes ago      22.6MB
```

- Use ENV var for version/branch to check out
- Set git clone depth to 1, pulling 11Mb instead of 78M
- Put build packages into a virtual group to remove all at once with apk
- Set EXPOSE port
- Move server command into ENTRYPOINT and args into CMD
- Move ENTRYPOINT/CMD to end of file to avoid re-building layers if
changed

May be better slightly faster to pull a release tarball instead of a `git clone`, but using git allows for building of any branch/tag.